### PR TITLE
update links in RGB Library Map

### DIFF
--- a/annexes/glossary.md
+++ b/annexes/glossary.md
@@ -17,7 +17,7 @@ Set of client-side data that proves the inclusion of a unique [commitment](gloss
 
 Acronym of Algorithmic logic unit Virtual Machine, it is a register-based virtual machine for smart contract validation and distributed computing, used but not limited to RGB contract validation.
 
-[Link](https://www.aluvm.org/)
+[Link](./rgb-library-map.md#aluvm).
 
 ### Assignment
 
@@ -181,6 +181,14 @@ The set of client-side data related to one or more [contracts](glossary.md#contr
 The most important [contract operation](glossary.md#contract-operation) that makes possible the transition of an RGB State to a New State, changing [state](glossary.md#contract-state) data and/or ownership.
 
 [Link](../rgb-state-and-operations/state-transitions.md#state-transitions-and-their-mechanics)
+
+### Strict Type System
+
+An infrastructure that allows to create complex types which are deterministically
+identified by their `semId`. It is used by schemas to precisely define the data type
+for their state.
+
+[Link](./rgb-library-map.md#strict-types).
 
 ### Taproot
 

--- a/annexes/rgb-library-map.md
+++ b/annexes/rgb-library-map.md
@@ -1,121 +1,77 @@
 # RGB Library Map
 
-<figure><img src="../.gitbook/assets/library_map.png" alt=""><figcaption><p><strong>The different code parts making up RGB Protocol and dependent libraries.</strong></p></figcaption></figure>
-
-## Client-side Validation
+## RGB Consensus
 
 **Repository:**
 
-* [https://github.com/LNP-BP/client\_side\_validation](https://github.com/LNP-BP/client\_side\_validation)
+* [https://github.com/rgb-protocol/rgb-consensus](https://github.com/rgb-protocol/rgb-consensus)
+
+**Rust Crate:**
+
+* [https://crates.io/crates/rgb-consensus](https://crates.io/crates/rgb-consensus)
+
+## RGB Operations
+
+**Repository:**
+
+* [https://github.com/rgb-protocol/rgb-ops](https://github.com/rgb-protocol/rgb-ops)
+
+**Rust Crate:**
+
+* [https://crates.io/crates/rgb-ops](https://crates.io/crates/rgb-ops)
+* [https://crates.io/crates/rgb-invoicing](https://crates.io/crates/rgb-invoicing)
+
+## RGB API and CLI
+
+**Repository:**
+
+* [https://github.com/rgb-protocol/rgb-api](https://github.com/rgb-protocol/rgb-api)
 
 **Rust Crates:**
 
-* [https://crates.io/crates/client\_side\_validation](https://crates.io/crates/client\_side\_validation)
-* [https://crates.io/crates/single\_use\_seals](https://crates.io/crates/single\_use\_seals)
+* [https://crates.io/crates/rgb-api](https://crates.io/crates/rgb-api)
+* [https://crates.io/crates/rgb-psbt-utils](https://crates.io/crates/rgb-psbt-utils)
+* [https://crates.io/crates/rgb-cmd](https://crates.io/crates/rgb-cmd)
 
-## Deterministic Bitcoin Commitments - DBC
+## RGB Schemas
 
 **Repository:**
 
-* [https://github.com/BP-WG/bp-core](https://github.com/BP-WG/bp-core)
+* [https://github.com/rgb-protocol/rgb-schemas/](https://github.com/rgb-protocol/rgb-schemas/)
 
 **Rust Crate:**
 
-* [https://crates.io/crates/bp-dbc](https://crates.io/crates/bp-dbc)
-
-## Multi Protocol Commitment - MPC
-
-**Repository:**
-
-* [https://github.com/LNP-BP/client\_side\_validation](https://github.com/LNP-BP/client\_side\_validation)
-
-**Rust Crate:**
-
-* [https://crates.io/crates/commit\_verify](https://crates.io/crates/commit\_verify)
-
-## Strict Types & Strict Encoding
-
-**Specifications:**
-
-* [https://www.strict-types.org/](https://www.strict-types.org/)
-
-**Repositories:**
-
-* [https://github.com/strict-types/strict-types](https://github.com/strict-types/strict-types)
-* [https://github.com/strict-types/strict-encoding](https://github.com/strict-types/strict-encoding)
-
-**Rust Crates:**
-
-* [https://crates.io/crates/strict\_types](https://crates.io/crates/strict\_types)
-* [https://crates.io/crates/strict\_encoding](https://crates.io/crates/strict\_encoding)
-
-## RGB Core
-
-**Repository:**
-
-* [https://github.com/RGB-WG/rgb-core](https://github.com/RGB-WG/rgb-core)
-
-**Rust Crate:**
-
-* [https://crates.io/crates/rgb-core](https://crates.io/crates/rgb-core)
-
-## RGB Standard Library & Wallet
-
-**Repository:**
-
-* [https://github.com/RGB-WG/rgb-std](https://github.com/RGB-WG/rgb-std)
-
-**Rust Crate:**
-
-* [https://crates.io/crates/rgb-std](https://crates.io/crates/rgb-std)
-
-## RGB CLI
-
-**Repository:**
-
-* [https://github.com/RGB-WG/rgb](https://github.com/RGB-WG/rgb)
-
-**Rust Crates:**
-
-* [https://crates.io/crates/rgb-cli](https://crates.io/crates/rgb-cli)
-* [https://crates.io/crates/rgb-wallet](https://crates.io/crates/rgb-wallet)
-
-## RGB Schemata
-
-**Repository:**
-
-* [https://github.com/RGB-WG/rgb-schemata/](https://github.com/RGB-WG/rgb-schemata/)
+* [https://crates.io/crates/rgb-schemas](https://crates.io/crates/rgb-schemas)
 
 ## ALuVM
 
-**Info:**
+**Repository:**
 
-* [https://www.aluvm.org/](https://www.aluvm.org/)
+* [https://github.com/rgb-protocol/rgb-aluvm](https://github.com/rgb-protocol/rgb-aluvm)
+
+**Rust Crate:**
+
+* [https://crates.io/crates/rgb-aluvm](https://crates.io/crates/rgb-aluvm)
+
+## Strict Types
 
 **Repositories:**
 
-* [https://github.com/AluVM/aluvm-spec](https://github.com/AluVM/aluvm-spec)
-* [https://github.com/AluVM/alure](https://github.com/AluVM/alure)
+* [https://github.com/rgb-protocol/rgb-strict-types](https://github.com/rgb-protocol/rgb-strict-types)
+* [https://github.com/rgb-protocol/rgb-strict-encoding](https://github.com/rgb-protocol/rgb-strict-encoding)
 
 **Rust Crates:**
 
-* [https://crates.io/crates/aluvm](https://crates.io/crates/aluvm)
-* [https://crates.io/crates/aluasm](https://crates.io/crates/aluasm)
+* [https://crates.io/crates/rgb-strict-types](https://crates.io/crates/rgb-strict-types)
+* [https://crates.io/crates/rgb-strict-encoding](https://crates.io/crates/rgb-strict-encoding)
+* [https://crates.io/crates/rgb-strict-encoding-derive](https://crates.io/crates/rgb-strict-encoding-derive)
 
-## Bitcoin Protocol - BP
-
-**Repositories:**
-
-* [https://github.com/BP-WG](https://github.com/BP-WG)
-  * [https://github.com/BP-WG/bp-core](https://github.com/BP-WG/bp-core)
-  * [https://github.com/BP-WG/bp-std](https://github.com/BP-WG/bp-std)
-  * [https://github.com/BP-WG/bp-wallet](https://github.com/BP-WG/bp-wallet)
-
-## Ubiquitous Deterministic Computing - UBIDECO
+## Ascii Armor
 
 **Repository:**
 
-* [https://github.com/UBIDECO](https://github.com/UBIDECO)
+* [https://github.com/rgb-protocol/rgb-ascii-armor](https://github.com/rgb-protocol/rgb-ascii-armor)
 
+**Rust Crate:**
 
-
+* [https://crates.io/crates/rgb-ascii-armor](https://crates.io/crates/rgb-ascii-armor)

--- a/rgb-contract-implementation/schema/README.md
+++ b/rgb-contract-implementation/schema/README.md
@@ -25,7 +25,7 @@ From a functional point of view, the **Schema construct addresses the following 
 Among the most important properties, a Schema:
 
 * Defines all the variables used in contract state and transitions using a specific
-  [strict type system](https://www.strict-types.org/) encoding. Such variables,
+  [strict type system](../../annexes/glossary.md#strict-type-system) encoding. Such variables,
   depending on their scope, may be of different types:
   * Metadata: related to a single operation
   * Owned state: created by an operation and consumed by a second one


### PR DESCRIPTION
The development of RGB v0.11.1 has recently moved on to the https://github.com/rgb-protocol organization, links are modified accordingly.