### PR TITLE
Fix contradiction about state-update synchronicity in state channels

### DIFF
--- a/distributed-computing-concepts/paradigms-of-distributed-computing.md
+++ b/distributed-computing-concepts/paradigms-of-distributed-computing.md
@@ -60,7 +60,7 @@ An important feature to take into account is the different ways through which St
 * Channel state must be **synchronous** between the counterparts.
 * Client-side validated state updates can be **asynchronous**.
 
-Naturally, if the client-side validated data are embedded in the state channels, the state update will be ultimately based on an asynchronous process.
+Naturally, if the client-side validated data are embedded in the state channels, the state update will ultimately be a synchronous process (it inherits the channel's synchronous update requirement).
 
 <figure><img src="../.gitbook/assets/triangle-bifi.png" alt=""><figcaption><p><strong>Blockchain is the base layer over which multiple-interacting layers can be constructed</strong></p></figcaption></figure>
 


### PR DESCRIPTION
Fixes #18

The conclusion contradicted the bullet right above it ("Channel state must be
**synchronous** between the counterparts"). Embedding client-side-validated
data into a state channel does not remove the channel's synchronous-update
requirement — the combined transfer inherits it.

Applies the exact wording proposed in the issue, which @St333p confirmed looks
good. One-line change, no further expansion per the discussion.