### PR TITLE
Remove Table of Contents from README.md + minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,49 +13,6 @@ RGB Protocol on Bitcoin — not to be confused with:
 For general information and education visit [rgb.info](https://rgb.info).
 {% endhint %}
 
-## Table of Contents
-
-### Distributed Computing Concepts
-
-* [Paradigms of Distributed Computing](distributed-computing-concepts/paradigms-of-distributed-computing.md)
-* [Client-side Validation](distributed-computing-concepts/client-side-validation.md)
-* [Single-use Seals and Proof of Publication](distributed-computing-concepts/single-use-seals.md)
-
-### Commitment Layer
-
-* [Commitment Schemes within Bitcoin and RGB](commitment-layer/commitment-schemes.md)
-* [Deterministic Bitcoin Commitments - DBC](commitment-layer/deterministic-bitcoin-commitments-dbc/)
-  * [Opret](commitment-layer/deterministic-bitcoin-commitments-dbc/opret.md)
-  * [Tapret](commitment-layer/deterministic-bitcoin-commitments-dbc/tapret.md)
-* [Multi Protocol Commitments - MPC](commitment-layer/multi-protocol-commitments-mpc.md)
-* [Anchors](commitment-layer/anchors.md)
-
-### RGB State and Operations
-
-* [Introduction to Smart Contracts and their States](rgb-state-and-operations/intro-smart-contract-states.md)
-* [Contract Operations](rgb-state-and-operations/state-transitions.md)
-* [Components of a Contract Operation](rgb-state-and-operations/components-of-a-contract-operation.md)
-* [Features of RGB State](rgb-state-and-operations/features-of-rgb-state.md)
-
-### RGB Contract Implementation
-
-* [Schema](rgb-contract-implementation/schema/)
-  * [Supported Schemas](rgb-contract-implementation/schema/supported-schemas.md)
-  * [Schema example: Non-Inflatable Assets](rgb-contract-implementation/schema/non-inflatable-fungible-asset-schema.md)
-
-### RGB over Lightning Network
-
-* [Lightning Network compatibility](rgb-over-lightning-network/lightning-network-compatibility.md)
-
-### Annexes
-
-* [Glossary](annexes/glossary.md)
-* [Contract Transfers](annexes/contract-transfers.md)
-* [Invoices](annexes/invoices.md)
-* [Commitments](annexes/commitments.md)
-* [RGB Library Map](annexes/rgb-library-map.md)
-* [Bitcoin Single-use Seals](annexes/single-use-seals-bitcoin.md)
-
 ## Credits
 
 The production of this documentation has been sponsored by [Bitfinex](https://www.bitfinex.com/) and the material provided is mostly based on a 3-day full-immersion seminar on RGB Protocol held by [Maxim Orlovsky](https://twitter.com/dr\_orlovsky) at the Tuscany Lightning Bootcamp in October 2023.

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -20,7 +20,7 @@
 ## RGB State and Operations
 
 * [Introduction to Smart Contracts and their States](rgb-state-and-operations/intro-smart-contract-states.md)
-* [Contract Operations](rgb-state-and-operations/state-transitions.md)
+* [State Transitions](rgb-state-and-operations/state-transitions.md)
 * [Components of a Contract Operation](rgb-state-and-operations/components-of-a-contract-operation.md)
 * [Features of RGB State](rgb-state-and-operations/features-of-rgb-state.md)
 

--- a/distributed-computing-concepts/client-side-validation.md
+++ b/distributed-computing-concepts/client-side-validation.md
@@ -20,7 +20,7 @@ However, from the point of view of the recipient of a transaction, the only aspe
 * The last state transition, that is represented by a transaction addressed to him.
 * The chronological sequence of transactions (and thus state transitions) leading up to the last state transition.
 
-Basically, what is relevant to the recipient is the [Directed Acyclic Graph](../annexes/glossary.md#directed-acyclic-graph-dag) which connects the history of the state transitions from the [Genesis](../annexes/glossary.md#genesis) to the last state addressed to him (a [Shard](../annexes/glossary.md#shard) of the whole data).
+Basically, what is relevant to the recipient is the Directed Acyclic Graph which connects the history from a set of coinbase transactions to the state addressed to him (a subset of the whole data).
 
 <figure><img src="../.gitbook/assets/transaction-graph-1.png" alt=""><figcaption><p><strong>The transaction graph of Public Blockchains cannot be sharded due to internal consistency.</strong></p></figcaption></figure>
 


### PR DESCRIPTION
- remove table of contents from README.md, which is just a copy of SUMMARY.md and needs to be kept in sync. The ToC appears in a sidebar anyways
- fix image descripion in client_side_validation.md
- rename "Contract Operations" section to "State Transitions", which is more aligned with its content